### PR TITLE
Disconnect upon session timeout, whatever the value of persistent-coo…

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,6 @@
 * Version 1.2.2 (unreleased)
+- Always invalidate the session in case of session timeout, so that
+  re-authentication with current coookie is impossible.
 
 
 * Version 1.2.1 (released 2023-08-22)

--- a/src/sec-mod-db.c
+++ b/src/sec-mod-db.c
@@ -201,8 +201,8 @@ void expire_client_entry(sec_mod_st *sec, client_entry_st * e)
 	if (e->in_use > 0)
 		e->in_use--;
 	if (e->in_use == 0) {
-		if (e->vhost->perm_config.config->persistent_cookies == 0 && (e->discon_reason == REASON_SERVER_DISCONNECT ||
-		    e->discon_reason == REASON_SESSION_TIMEOUT || (e->session_is_open && e->discon_reason == REASON_USER_DISCONNECT))) {
+		if (e->discon_reason == REASON_SESSION_TIMEOUT || e->discon_reason == REASON_SERVER_DISCONNECT ||
+		    (e->vhost->perm_config.config->persistent_cookies == 0 && e->session_is_open && e->discon_reason == REASON_USER_DISCONNECT)) {
 			seclog(sec, LOG_INFO, "invalidating session of user '%s' "SESSION_STR,
 			       e->acct_info.username, e->acct_info.safe_id);
 			/* immediately disconnect the user */


### PR DESCRIPTION
…kies

This implements the documented behaviour:

	# The time (in seconds) that a client is allowed to stay connected
	# Unset to disable. When set a client will be disconnected after being
	# continuously connected for this amount of time, and its cookies will
	# be invalidated (i.e., re-authentication will be required).
	#session-timeout = 86400

The persistent-cookies option is documented to override in case of REASON_USER_DISCONNECT, but not in case of REASON_SESSION_TIMEOUT:

	# If this is enabled (not recommended) the cookies will stay
	# valid even after a user manually disconnects, and until they
	# expire. This may improve roaming with some broken clients.
	#persistent-cookies = true

Not totally sure about REASON_SERVER_DISCONNECT (authentication timeout or hang due to server or kernel bug), but I don't see why it would not result in unconditional session termination, like REASON_SESSION_TIMEOUT.